### PR TITLE
Remove unnecessary test

### DIFF
--- a/1-Initial-Setup/1.5-Additional-Process-Hardening.bats
+++ b/1-Initial-Setup/1.5-Additional-Process-Hardening.bats
@@ -29,7 +29,4 @@
 
     run bash -c "grep \"fs.suid_dumpable\" /etc/sysctl.conf /etc/sysctl.d/*"
     [[ "$output" == *"fs.suid_dumpable = 0" ]]
-
-    run bash -c "systemctl is-enabled coredump.service"
-    [[ "$output" == *"enabled"* ]] || [[ "$output" == *"masked"* ]] || [[ "$output" == *"disabled"* ]]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove unnecessary test in 1.5.4
 
 ## [1.0.0] - 2021-06-15
 ### Added


### PR DESCRIPTION
This coredump command does not have to be in one of the tested states.
The coredump service can also be not installed.
This command is only for getting information if coredump is installed.