### PR TITLE
Use correct match on 0 in 1.6.1.3 and 1.6.1.4

### DIFF
--- a/1-Initial-Setup/1.6-Mandatory-Access-Control.bats
+++ b/1-Initial-Setup/1.6-Mandatory-Access-Control.bats
@@ -17,30 +17,30 @@
 }
 
 @test "1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)" {
-    run bash -c "apparmor_status | grep profiles | grep '0 profiles are loaded.'"
+    run bash -c "apparmor_status | grep profiles | grep -E '^0 profiles are loaded.'"
     [ "$status" -eq 1 ]
 
     local enforce_mode
-    run bash -c "apparmor_status | grep profiles | grep '0 profiles are in enforce mode.'"
+    run bash -c "apparmor_status | grep profiles | grep -E '^0 profiles are in enforce mode.'"
     enforce_mode=$?
 
     local complain_mode
-    run bash -c "apparmor_status | grep profiles | grep '0 profiles are in complain mode.'"
+    run bash -c "apparmor_status | grep profiles | grep -E '^0 profiles are in complain mode.'"
     complain_mode=$?
 
     [ "$enforce_mode" -eq 0 ] || [ "$complain_mode" -eq 0 ]
 
-    run bash -c "apparmor_status | grep processes | grep '0 processes are unconfined'"
+    run bash -c "apparmor_status | grep processes | grep -E '^0 processes are unconfined'"
     [ "$status" -eq 0 ]
 }
 
 @test "1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)" {
-    run bash -c "apparmor_status | grep '0 profiles are loaded'"
+    run bash -c "apparmor_status | grep -E '^0 profiles are loaded'"
     [ "$status" -eq 1 ]
 
-    run bash -c "apparmor_status | grep profiles | grep '0 profiles are in complain mode.'"
+    run bash -c "apparmor_status | grep profiles | grep -E '^0 profiles are in complain mode.'"
     [ "$status" -eq 0 ]
 
-    run bash -c "apparmor_status | grep processes | grep '0 processes are unconfined'"
+    run bash -c "apparmor_status | grep processes | grep -E '^0 processes are unconfined'"
     [ "$status" -eq 0 ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix newline mistakes in script 6.2.6
 - Fix newline mistakes in script 6.2.7
 - Fix additional partitions tests 1.1.10, 1.1.11, 1.1.15, 1.1.16 and 1.1.17
+- Use correct match on 0 in 1.6.1.3 and 1.6.1.4
 
 ## [1.0.0] - 2021-06-15
 ### Added


### PR DESCRIPTION
Check if there is a 0 at the beginning of the line.
This prevents matches on lines which have more
characters in front of the zero, e.g.
"20 profiles are loaded"